### PR TITLE
Implement SNTP clock sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ ESP32-CAM project that captures 5 seconds of video as individual JPEG frames and
 
 3. The `config.h` file is excluded from git to keep your credentials private.
 
+### Time Synchronization
+
+`config.h` also contains `TZ_INFO` and NTP server settings. Set `TZ_INFO` to a
+POSIX TZ string such as `"EST5EDT,M3.2.0/2,M11.1.0/2"` for automatic daylight
+saving adjustments. The clock is synchronized at boot whenever WiFi and Internet
+access are available.
+
 ### Build and Upload
 
 Upload the `karting-cam.ino` file to your ESP32-CAM using the Arduino IDE or PlatformIO.
@@ -29,3 +36,4 @@ Upload the `karting-cam.ino` file to your ESP32-CAM using the Arduino IDE or Pla
 - Saves frames as frame_000001.jpg, frame_000002.jpg, etc. on the SD card
 - Web interface to view and download files
 - Can operate as WiFi Access Point or connect to existing network
+- Automatically syncs the on-board RTC with NTP when WiFi has internet access

--- a/config.h.example
+++ b/config.h.example
@@ -12,4 +12,12 @@ static const char *STA_SSID = "YOUR_WIFI_SSID_HERE";
 static const char *STA_PASS = "YOUR_WIFI_PASSWORD_HERE";
 #endif
 
-#endif // CONFIG_H 
+/* ----------------------------- Time Sync ----------------------------- */
+// POSIX TZ string (handles DST automatically). Replace with your zone.
+// Example: "EST5EDT,M3.2.0/2,M11.1.0/2" for US Eastern time
+static const char *TZ_INFO = "UTC0";
+
+static const char *NTP_SERVER1 = "pool.ntp.org";
+static const char *NTP_SERVER2 = "time.nist.gov";
+
+#endif // CONFIG_H

--- a/karting-cam.ino
+++ b/karting-cam.ino
@@ -90,7 +90,13 @@ static void syncClock() {
     return;
   }
 
-  configTime(TZ_INFO, NTP_SERVER1, NTP_SERVER2);
+  // Configure time with GMT offset and daylight saving offset
+  // For UTC: gmtOffset_sec = 0, daylightOffset_sec = 0
+  configTime(0, 0, NTP_SERVER1, NTP_SERVER2);
+
+  // Set timezone using the POSIX string
+  setenv("TZ", TZ_INFO, 1);
+  tzset();
 
   struct tm timeinfo;
   if (getLocalTime(&timeinfo, 10000)) {

--- a/karting-cam.ino
+++ b/karting-cam.ino
@@ -18,6 +18,7 @@
 #include <SD_MMC.h>
 #include <WiFi.h>
 #include <esp_camera.h>
+#include <time.h>
 
 /* ---------------------- Camera pin assignment ---------------------- */
 /*  These match the WROOM-32E + OV2640 wiring you posted.              */
@@ -80,6 +81,23 @@ static void startWiFi() {
 #ifdef CONFIG_LWIP_TCP_SND_BUF_DEFAULT
 // TCP send buffer already optimized in build config
 #endif
+}
+
+/* --------------- Helper: synchronize time via SNTP ----------------- */
+static void syncClock() {
+  if (WiFi.status() != WL_CONNECTED) {
+    LOG_PRINTLN("[SNTP] Wi-Fi not connected, skipping time sync");
+    return;
+  }
+
+  configTime(TZ_INFO, NTP_SERVER1, NTP_SERVER2);
+
+  struct tm timeinfo;
+  if (getLocalTime(&timeinfo, 10000)) {
+    LOG_PRINTF("[SNTP] Time synchronized: %s", asctime(&timeinfo));
+  } else {
+    LOG_PRINTLN("[SNTP] Failed to obtain time");
+  }
 }
 
 /* ------------------ Helper: configure the camera ------------------- */
@@ -235,6 +253,7 @@ void setup() {
   logInit();
 
   startWiFi();
+  syncClock();
   startWebServer();
 }
 


### PR DESCRIPTION
## Summary
- add timezone and NTP server settings to `config.h.example`
- document time synchronization steps in README
- sync the RTC after WiFi connection using `configTime`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68479143cebc8323a9b621cfbae9860c